### PR TITLE
Port over Windows quoting related fixes

### DIFF
--- a/weasel/_util/general.py
+++ b/weasel/_util/general.py
@@ -91,8 +91,7 @@ def run_command(
         if isinstance(command, str):
             cmd_str = command
         else:  # list
-            # TODO list2cmdline is an intentionally undocumented internal Python
-            # function, check if we want to use this.
+            # NOTE: list2cmdline is an intentionally undocumented internal Python function
             cmd_str = subprocess.list2cmdline(command)
             tool = command[0]
     else:


### PR DESCRIPTION
This is a continuation of https://github.com/explosion/spaCy/pull/11378, which resolves issues with how quotes are handled on Windows. 

The short explanation is that before this PR, `shlex` with `posix=False` is used on Windows, which looks reasonable but is not correct, because it refers to a non-posix-standard shell run on Unix-like OSes, rather than the Windows shell. 

Following this change, on Windows strings are passed directly to `subprocess.run` on Windows without being split, since the underlying Windows system API operates on strings. 

As a result, quotes work basically the same as they do in the `cmd` shell on Windows. This is different than bash, and so by convention single quotes will typically cause errors, for example. 

This PR is based on #3, and should be merged after that. Any changes there may still cause conflicts, but they shouldn't be too complicated to resolve.